### PR TITLE
Added exception for GNU/Linux where ru_RU.UTF8 is right locale.

### DIFF
--- a/dtp_parser/update_regions.py
+++ b/dtp_parser/update_regions.py
@@ -20,7 +20,12 @@ django.setup()
 from dtpmapapp import models
 from django.shortcuts import get_object_or_404
 
-locale.setlocale(locale.LC_TIME, "ru_RU")
+try:
+    locale.setlocale(locale.LC_TIME, "ru_RU")
+except locale.Error:
+    # right locale for GNU/Linux
+    locale.setlocale(locale.LC_TIME, "ru_RU.UTF8")
+
 warnings.filterwarnings('ignore')
 
 

--- a/parser.py
+++ b/parser.py
@@ -12,7 +12,12 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../dtpmap/dtpmap'))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dtpmap.settings")
 django.setup()
 
-locale.setlocale(locale.LC_TIME, "ru_RU")
+try:
+    locale.setlocale(locale.LC_TIME, "ru_RU")
+except locale.Error:
+    # right locale for GNU/Linux
+    locale.setlocale(locale.LC_TIME, "ru_RU.UTF8")
+
 warnings.filterwarnings('ignore')
 
 from dtpmapapp import models


### PR DESCRIPTION
Possible solution of #20.
There is error when you try to set locale as `ru_RU` in GNU/Linux (ubuntu, debian tested). In this case you need to set `ru_RU.UTF8` locale. I added exception case for `locale.Error` error. 
