### PR TITLE
Add version tag for CSS file - helps with old cached styles

### DIFF
--- a/dtpmapapp/templatetags/md5url.py
+++ b/dtpmapapp/templatetags/md5url.py
@@ -1,0 +1,43 @@
+import hashlib
+import threading
+from os import path
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+class UrlCache(object):
+    _md5_sum = {}
+    _lock = threading.Lock()
+
+    @classmethod
+    def get_md5(cls, file):
+        try:
+            return cls._md5_sum[file]
+        except KeyError:
+            with cls._lock:
+                try:
+                    for root_url in settings.STATICFILES_DIRS:
+                        md5 = cls.calc_md5(path.join(root_url, file))[:8]
+                        value = '%s%s?v=%s' % (settings.STATIC_URL, file, md5)
+                except IsADirectoryError:
+                    value = settings.STATIC_URL + file
+                cls._md5_sum[file] = value
+                return value
+
+    @classmethod
+    def calc_md5(cls, file_path):
+        with open(file_path, 'rb') as fh:
+            m = hashlib.md5()
+            while True:
+                data = fh.read(8192)
+                if not data:
+                    break
+                m.update(data)
+            return m.hexdigest()
+
+
+@register.simple_tag
+def md5url(model_object):
+    return UrlCache.get_md5(model_object)

--- a/templates/area.html
+++ b/templates/area.html
@@ -1,6 +1,7 @@
 <!doctype html>
 
 {% load static %}
+{% load md5url %}
 {% load render_bundle from webpack_loader %}
 
 <html lang="ru">
@@ -15,7 +16,7 @@
         <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,900&amp;subset=cyrillic,cyrillic-ext" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
         <link rel="stylesheet" href="https://unpkg.com/react-select@1.2.1/dist/react-select.css">
-        <link rel="stylesheet" href="{% static 'css/dtp-map.css' %}">
+        <link rel="stylesheet" href="{% md5url 'css/dtp-map.css' %}">
         <script src='https://api.mapbox.com/mapbox-gl-js/v0.47.0/mapbox-gl.js'></script>
         <link href='https://api.mapbox.com/mapbox-gl-js/v0.47.0/mapbox-gl.css' rel='stylesheet' />
     </head>

--- a/templates/head.html
+++ b/templates/head.html
@@ -1,4 +1,5 @@
 {% load staticfiles %}
+{% load md5url %}
 <!-- Yandex.Metrika counter -->
 <script type="text/javascript" >
     (function (d, w, c) {
@@ -57,7 +58,7 @@
           integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB"
           crossorigin="anonymous">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
-    <link href="{% static 'css/style.css' %}" rel="stylesheet" type="text/css">
+    <link href="{% md5url 'css/style.css' %}" rel="stylesheet" type="text/css">
 
 
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,900&amp;subset=cyrillic,cyrillic-ext" rel="stylesheet">


### PR DESCRIPTION
На мобильных устройствах очень тяжело сбрасывать кеш для отдельного сайта - предлагаю явно добавлять версию (MD5 hash) к имени CSS файла.